### PR TITLE
feat: replace Heptio Ark by Velero

### DIFF
--- a/indice.md
+++ b/indice.md
@@ -138,7 +138,7 @@
 4. PersistentVolumes
 5. Worker-nodes
 6. Actualización de un clúster
-7. Heptio Ark
+7. Velero
 8. Buenas prácticas
 
 ## Tema 13 - Observabilidad de Kubernetes


### PR DESCRIPTION
Cambio para remplazar [Heptio Ark por Velero](https://velero.io/docs/v0.11.0/migrating-to-velero/).

---

Heptio Ark fue renombrado a Velero en la release [0.11.0](https://github.com/vmware-tanzu/velero/releases/tag/v0.11.0) el pasado 28/02/2019.